### PR TITLE
Implement PHP JWT session validation

### DIFF
--- a/frontend-php/includes/auth.php
+++ b/frontend-php/includes/auth.php
@@ -1,0 +1,47 @@
+<?php
+function base64url_decode_custom(string $data): string {
+    $remainder = strlen($data) % 4;
+    if ($remainder) {
+        $data .= str_repeat('=', 4 - $remainder);
+    }
+    return base64_decode(strtr($data, '-_', '+/'));
+}
+
+function verify_jwt(string $token, string $secret) {
+    $parts = explode('.', $token);
+    if (count($parts) !== 3) {
+        return false;
+    }
+    list($header64, $payload64, $signature64) = $parts;
+    $signature = base64url_decode_custom($signature64);
+    $expected = hash_hmac('sha256', "$header64.$payload64", $secret, true);
+    if (!hash_equals($expected, $signature)) {
+        return false;
+    }
+    $payload = json_decode(base64url_decode_custom($payload64), true);
+    if (!$payload) {
+        return false;
+    }
+    if (isset($payload['exp']) && time() >= $payload['exp']) {
+        return false;
+    }
+    return $payload;
+}
+
+function require_auth(): array {
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
+    if (!isset($_SESSION['token'])) {
+        header('Location: login.php');
+        exit();
+    }
+    $payload = verify_jwt($_SESSION['token'], 'aslkdja98yhoihafpihf11asf124');
+    if ($payload === false) {
+        session_destroy();
+        header('Location: login.php');
+        exit();
+    }
+    return $payload;
+}
+?>

--- a/frontend-php/public/index.php
+++ b/frontend-php/public/index.php
@@ -1,11 +1,7 @@
 <?php
 session_start();
-
-if (isset($_SESSION['aluno_logado']) && $_SESSION['aluno_logado'] === true) {
-    echo "Sessão ativa. ID do aluno: " . $_SESSION['aluno_id'];
-} else {
-    echo "Usuário não está logado.";
-}
+require_once '../includes/auth.php';
+require_auth();
 ?>
 <!DOCTYPE html>
 <html lang="pt-br">

--- a/frontend-php/public/listarEventos.php
+++ b/frontend-php/public/listarEventos.php
@@ -1,11 +1,7 @@
 <?php
 session_start();
-
-if (isset($_SESSION['aluno_logado']) && $_SESSION['aluno_logado'] === true) {
-    echo "Sessão ativa. ID do aluno: " . $_SESSION['aluno_id'];
-} else {
-    echo "Usuário não está logado.";
-}
+require_once '../includes/auth.php';
+require_auth();
 require_once '../classes/Eventos.php';
 require_once '../classes/Palestrantes.php';
 

--- a/frontend-php/public/login.php
+++ b/frontend-php/public/login.php
@@ -20,6 +20,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $_SESSION['aluno_id'] = $login['body']['aluno']['id'];
                 $_SESSION['aluno_nome'] = $login['body']['aluno']['nome'];
                 $_SESSION['aluno_email'] = $login['body']['aluno']['email'];
+                $_SESSION['token'] = $login['body']['token'];
                 echo $_SESSION['aluno_id'];
                 header("Location: index.php");
                 exit();

--- a/frontend-php/public/perfilAluno.php
+++ b/frontend-php/public/perfilAluno.php
@@ -1,15 +1,11 @@
 <?php
 session_start();
+require_once '../includes/auth.php';
+require_auth();
 
 require_once '../classes/Inscricao.php';
 require_once '../classes/Eventos.php';
 require_once '../classes/Palestrantes.php';
-
-if (isset($_SESSION['aluno_logado']) && $_SESSION['aluno_logado'] === true) {
-    echo "Sessão ativa. ID do aluno: " . $_SESSION['aluno_id'];
-} else {
-    echo "Usuário não está logado.";
-}
 
 $inscricaoObj = new Inscricao();
 $eventoObj = new Eventos();

--- a/frontend-php/public/visualizarEvento.php
+++ b/frontend-php/public/visualizarEvento.php
@@ -1,11 +1,7 @@
 <?php
 session_start();
-
-if (isset($_SESSION['aluno_logado']) && $_SESSION['aluno_logado'] === true) {
-    echo "Sessão ativa. ID do aluno: " . $_SESSION['aluno_id'];
-} else {
-    echo "Usuário não está logado.";
-}
+require_once '../includes/auth.php';
+require_auth();
 
 require_once '../classes/Eventos.php';
 require_once '../classes/Palestrantes.php';

--- a/frontend-php/public/visualizarPalestrante.php
+++ b/frontend-php/public/visualizarPalestrante.php
@@ -1,11 +1,7 @@
 <?php
 session_start();
-
-if (isset($_SESSION['aluno_logado']) && $_SESSION['aluno_logado'] === true) {
-    echo "Sessão ativa. ID do aluno: " . $_SESSION['aluno_id'];
-} else {
-    echo "Usuário não está logado.";
-}
+require_once '../includes/auth.php';
+require_auth();
 require_once '../classes/Palestrantes.php';
 
 $palestrante = new Palestrantes();


### PR DESCRIPTION
## Summary
- add auth helper with manual JWT validation
- store JWT token on login success
- require token validation on protected pages

## Testing
- `npm test --prefix api-node` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684dcfe4a24c8321a16436b9502b5c3b